### PR TITLE
FIX: respect 'bytes' kwarg

### DIFF
--- a/viscm/gui.py
+++ b/viscm/gui.py
@@ -103,8 +103,11 @@ class TransformedCMap(matplotlib.colors.Colormap):
         self.base_cmap = base_cmap
 
     def __call__(self, *args, **kwargs):
-        fx = self.base_cmap(*args, **kwargs)
+        bts = kwargs.pop('bytes', False)
+        fx = self.base_cmap(*args, bytes=False, **kwargs)
         tfx = self.transform(fx)
+        if bts:
+            return (tfx * 255).astype('uint8')
         return tfx
 
     def set_bad(self, *args, **kwargs):


### PR DESCRIPTION
In mpl 2.0 the value of the 'bytes' kwarg to `ColorMap.__call__`
while making an image.

The viscm transform code was assuming that it get a float result from
the call to base_cmap() and the external code was expected back uint8
values.

The 'bytes' kwarg is now caught and applied on the way out if needed.
