### PR TITLE
Fix crash when the file save dialog is cancelled

### DIFF
--- a/viscm/gui.py
+++ b/viscm/gui.py
@@ -1107,7 +1107,8 @@ class ViewerWindow(QtWidgets.QMainWindow):
             caption="Save file",
             directory=self.cmapname + ".png",
             filter="Image Files (*.png *.jpg *.bmp)")
-        self.viscm.save_figure(fileName)
+        if fileName:
+            self.viscm.save_figure(fileName)
 
 
 class EditorWindow(QtWidgets.QMainWindow):
@@ -1296,7 +1297,8 @@ class EditorWindow(QtWidgets.QMainWindow):
             caption="Export file",
             directory=self.viscm_editor.name + ".py",
             filter=".py (*.py)")
-        self.viscm_editor.export_py(fileName)
+        if fileName:
+            self.viscm_editor.export_py(fileName)
 
     def fileQuit(self):
         self.close()
@@ -1309,7 +1311,8 @@ class EditorWindow(QtWidgets.QMainWindow):
             caption="Save file",
             directory=self.viscm_editor.name + ".jscm",
             filter="JSCM Files (*.jscm)")
-        self.viscm_editor.save_colormap(fileName)
+        if fileName:
+            self.viscm_editor.save_colormap(fileName)
 
     def loadviewer(self):
         newfig = plt.figure()


### PR DESCRIPTION
The filename is an empty string when the file save dialog is cancelled, which results in an attempt to open a non-existent file in `ViewerWindow`'s `save()`, `EditorWindow`'s `export()` and `save()`. Since the error isn't caught, viscm terminates. This patch checks if the returned string is empty and if it is, no file I/O operation is performed.