### PR TITLE
Fix compatibility with Matplotlib 3.7 and Qt6.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ Dependencies:
   * `colorspacious <https://pypi.python.org/pypi/colorspacious>`_
   * Matplotlib
   * NumPy
+  * one of PyQt6, PySide6, PyQt5 (>=5.13.1), or PySide2
 
 License:
   MIT, see LICENSE.txt for details.

--- a/viscm/bezierbuilder.py
+++ b/viscm/bezierbuilder.py
@@ -42,6 +42,10 @@ from matplotlib.lines import Line2D
 from matplotlib.backends.qt_compat import QtGui, QtCore
 from .minimvc import Trigger
 
+
+Qt = QtCore.Qt
+
+
 class ControlPointModel(object):
     def __init__(self, xp, yp, fixed=None):
         # fixed is either None (if no point is fixed) or and index of a fixed
@@ -113,12 +117,13 @@ class ControlPointBuilder(object):
         if event.inaxes != self.ax:
             return
         res, ind = self.control_polygon.contains(event)
-        if res and modkey == QtCore.Qt.NoModifier:
+        if res and modkey == Qt.KeyboardModifier.NoModifier:
             self._index = ind["ind"][0]
-        if res and (modkey == QtCore.Qt.ControlModifier or self.mode == "remove"):
+        if res and (modkey == Qt.KeyboardModifier.ControlModifier
+                    or self.mode == "remove"):
             # Control-click deletes
             self.control_point_model.remove_point(ind["ind"][0])
-        if (modkey == QtCore.Qt.ShiftModifier or self.mode == "add"):
+        if (modkey == Qt.KeyboardModifier.ShiftModifier or self.mode == "add"):
 
             # Adding a new point. Find the two closest points and insert it in
             # between them.

--- a/viscm/gui.py
+++ b/viscm/gui.py
@@ -15,7 +15,7 @@ import numpy as np
 #matplotlib.rcParams['backend'] = "QT4AGG"
 # Do this first before any other matplotlib imports, to force matplotlib to
 # use a Qt backend
-from matplotlib.backends.qt_compat import QtWidgets, QtCore, QtGui, _getSaveFileName
+from matplotlib.backends.qt_compat import QtWidgets, QtCore, QtGui
 
 try:
     from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
@@ -37,6 +37,9 @@ from scipy.interpolate import UnivariateSpline
 from colorspacious import (cspace_converter, cspace_convert,
                            CIECAM02Space, CIECAM02Surround)
 from .minimvc import Trigger
+
+
+Qt = QtCore.Qt
 
 
 # The correct L_A value for the standard sRGB viewing conditions is:
@@ -1033,8 +1036,8 @@ def main(argv):
     if args.quit:
         sys.exit()
 
-    figureCanvas.setSizePolicy(QtWidgets.QSizePolicy.Expanding,
-                               QtWidgets.QSizePolicy.Expanding)
+    figureCanvas.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding,
+                               QtWidgets.QSizePolicy.Policy.Expanding)
     figureCanvas.updateGeometry()
 
     mainwindow.resize(800, 600)
@@ -1050,7 +1053,7 @@ def main(argv):
     import signal
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-    app.exec_()
+    (getattr(app, "exec", None) or getattr(app, "exec_"))()
 
 def about():
     QtWidgets.QMessageBox.about(None, "VISCM",
@@ -1061,19 +1064,17 @@ def about():
 class ViewerWindow(QtWidgets.QMainWindow):
     def __init__(self, figurecanvas, viscm, cmapname, parent=None):
         QtWidgets.QMainWindow.__init__(self, parent)
-        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         self.main_widget = QtWidgets.QWidget(self)
         self.cmapname = cmapname
 
         file_menu = QtWidgets.QMenu('&File', self)
-        file_menu.addAction('&Save', self.save,
-                                QtCore.Qt.CTRL + QtCore.Qt.Key_S)
-        file_menu.addAction('&Quit', self.fileQuit,
-                                QtCore.Qt.CTRL + QtCore.Qt.Key_Q)
+        file_menu.addAction('&Save', self.save).setShortcut('Ctrl+S')
+        file_menu.addAction('&Quit', self.fileQuit).setShortcut('Ctrl+Q')
 
         options_menu = QtWidgets.QMenu('&Options', self)
-        options_menu.addAction('&Toggle Gamut', self.toggle_gamut,
-                                QtCore.Qt.CTRL + QtCore.Qt.Key_G)
+        options_menu.addAction(
+            '&Toggle Gamut', self.toggle_gamut).setShortcut('Ctrl+G')
 
         help_menu = QtWidgets.QMenu('&Help', self)
         help_menu.addAction('&About', about)
@@ -1103,9 +1104,8 @@ class ViewerWindow(QtWidgets.QMainWindow):
         self.fileQuit()
 
     def save(self):
-        fileName, _ = _getSaveFileName(
-            caption="Save file",
-            directory=self.cmapname + ".png",
+        fileName, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, "Save file", self.cmapname + ".png",
             filter="Image Files (*.png *.jpg *.bmp)")
         if fileName:
             self.viscm.save_figure(fileName)
@@ -1114,19 +1114,17 @@ class ViewerWindow(QtWidgets.QMainWindow):
 class EditorWindow(QtWidgets.QMainWindow):
     def __init__(self, figurecanvas, viscm_editor, parent=None):
         QtWidgets.QMainWindow.__init__(self, parent)
-        self.setAttribute(QtCore.Qt.WA_DeleteOnClose)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose)
         self.viscm_editor = viscm_editor
 
         file_menu = QtWidgets.QMenu('&File', self)
-        file_menu.addAction('&Save', self.save,
-                                QtCore.Qt.CTRL + QtCore.Qt.Key_S)
+        file_menu.addAction('&Save', self.save).setShortcut('Ctrl+S')
         file_menu.addAction("&Export .py", self.export)
-        file_menu.addAction('&Quit', self.fileQuit,
-                                QtCore.Qt.CTRL + QtCore.Qt.Key_Q)
+        file_menu.addAction('&Quit', self.fileQuit).setShortcut('Ctrl+Q')
 
         options_menu = QtWidgets.QMenu('&Options', self)
-        options_menu.addAction('&Load in Viewer', self.loadviewer,
-                                QtCore.Qt.CTRL + QtCore.Qt.Key_V)
+        options_menu.addAction(
+            '&Load in Viewer', self.loadviewer).setShortcut('Ctrl+V')
 
         help_menu = QtWidgets.QMenu('&Help', self)
         help_menu.addAction('&About', about)
@@ -1138,21 +1136,23 @@ class EditorWindow(QtWidgets.QMainWindow):
 
         self.main_widget = QtWidgets.QWidget(self)
 
-        self.max_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.max_slider = QtWidgets.QSlider(Qt.Orientation.Horizontal)
         self.max_slider.setMinimum(0)
         self.max_slider.setMaximum(100)
         self.max_slider.setValue(viscm_editor.max_Jp)
-        self.max_slider.setTickPosition(QtWidgets.QSlider.TicksBelow)
+        self.max_slider.setTickPosition(
+            QtWidgets.QSlider.TickPosition.TicksBelow)
         self.max_slider.setTickInterval(10)
         self.max_slider.valueChanged.connect(self.updatejp)
         self.max_slider_num = QtWidgets.QLabel(str(viscm_editor.max_Jp))
         self.max_slider_num.setFixedWidth(30)
 
-        self.min_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+        self.min_slider = QtWidgets.QSlider(Qt.Orientation.Horizontal)
         self.min_slider.setMinimum(0)
         self.min_slider.setMaximum(100)
         self.min_slider.setValue(viscm_editor.min_Jp)
-        self.min_slider.setTickPosition(QtWidgets.QSlider.TicksBelow)
+        self.min_slider.setTickPosition(
+            QtWidgets.QSlider.TickPosition.TicksBelow)
         self.min_slider.setTickInterval(10)
         self.min_slider.valueChanged.connect(self.updatejp)
         self.min_slider_num = QtWidgets.QLabel(str(viscm_editor.min_Jp))
@@ -1176,7 +1176,7 @@ class EditorWindow(QtWidgets.QMainWindow):
         mainlayout.addLayout(min_slider_layout)
 
         if viscm_editor.cmtype == "diverging":
-            smoothness_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal)
+            smoothness_slider = QtWidgets.QSlider(Qt.Horizontal)
             # We want the slider to vary filter_k exponentially between 5 and
             # 1000. So it should go from [log10(5), log10(1000)]
             # which is about [0.699, 3.0]
@@ -1193,7 +1193,7 @@ class EditorWindow(QtWidgets.QMainWindow):
             metrics = QtGui.QFontMetrics(smoothness_slider_num.font())
             max_width = metrics.width("1000.00")
             smoothness_slider_num.setFixedWidth(max_width)
-            smoothness_slider_num.setAlignment(QtCore.Qt.AlignRight)
+            smoothness_slider_num.setAlignment(Qt.AlignRight)
             self.smoothness_slider_num = smoothness_slider_num
 
             smoothness_slider_layout = QtWidgets.QHBoxLayout()
@@ -1208,42 +1208,30 @@ class EditorWindow(QtWidgets.QMainWindow):
             viscm_editor.cmap_model.filter_k_trigger.add_callback(
                 self.update_smoothness_slider)
 
-        self.moveAction = QtWidgets.QAction("Drag points", self)
+        self.toolbar = self.addToolBar('Tools')
+        self.moveAction = self.toolbar.addAction("Drag points")
         self.moveAction.triggered.connect(self.set_move_mode)
         self.moveAction.setCheckable(True)
-
-        self.addAction = QtWidgets.QAction("Add points", self)
+        self.addAction = self.toolbar.addAction("Add points")
         self.addAction.triggered.connect(self.set_add_mode)
         self.addAction.setCheckable(True)
-
-        self.removeAction = QtWidgets.QAction("Remove points", self)
+        self.removeAction = self.toolbar.addAction("Remove points")
         self.removeAction.triggered.connect(self.set_remove_mode)
         self.removeAction.setCheckable(True)
-
-        self.swapAction = QtWidgets.QAction("Flip brightness", self)
+        self.toolbar.addSeparator()
+        self.swapAction = self.toolbar.addAction("Flip brightness")
         self.swapAction.triggered.connect(self.swapjp)
-        renameAction = QtWidgets.QAction("Rename colormap", self)
+        self.toolbar.addSeparator()
+        renameAction = self.toolbar.addAction("Rename colormap")
         renameAction.triggered.connect(self.rename)
-
-        saveAction = QtWidgets.QAction('Save', self)
+        saveAction = self.toolbar.addAction("Save")
         saveAction.triggered.connect(self.save)
-
-
-        self.toolbar = self.addToolBar('Tools')
-        self.toolbar.addAction(self.moveAction)
-        self.toolbar.addAction(self.addAction)
-        self.toolbar.addAction(self.removeAction)
-        self.toolbar.addSeparator()
-        self.toolbar.addAction(self.swapAction)
-        self.toolbar.addSeparator()
-        self.toolbar.addAction(renameAction)
-        self.toolbar.addAction(saveAction)
 
         self.moveAction.setChecked(True)
 
         self.main_widget.setFocus()
         figurecanvas.setFocus()
-        figurecanvas.setFocusPolicy(QtCore.Qt.StrongFocus)
+        figurecanvas.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
         self.setCentralWidget(self.main_widget)
 
     def rename(self):
@@ -1293,9 +1281,8 @@ class EditorWindow(QtWidgets.QMainWindow):
         self.viscm_editor.bezier_builder.mode = "remove"
 
     def export(self):
-        fileName, _ = _getSaveFileName(
-            caption="Export file",
-            directory=self.viscm_editor.name + ".py",
+        fileName, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, "Export file", self.viscm_editor.name + ".py",
             filter=".py (*.py)")
         if fileName:
             self.viscm_editor.export_py(fileName)
@@ -1307,9 +1294,8 @@ class EditorWindow(QtWidgets.QMainWindow):
         self.fileQuit()
 
     def save(self):
-        fileName, _ = _getSaveFileName(
-            caption="Save file",
-            directory=self.viscm_editor.name + ".jscm",
+        fileName, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, "Save file", self.viscm_editor.name + ".jscm",
             filter="JSCM Files (*.jscm)")
         if fileName:
             self.viscm_editor.save_colormap(fileName)
@@ -1320,8 +1306,8 @@ class EditorWindow(QtWidgets.QMainWindow):
         cm = self.viscm_editor.show_viscm()
         v = viscm(cm, name=self.viscm_editor.name, figure=newfig)
 
-        newcanvas.setSizePolicy(QtWidgets.QSizePolicy.Expanding,
-                                QtWidgets.QSizePolicy.Expanding)
+        newcanvas.setSizePolicy(QtWidgets.QSizePolicy.Policy.Expanding,
+                                QtWidgets.QSizePolicy.Policy.Expanding)
         newcanvas.updateGeometry()
 
         newwindow = ViewerWindow(newcanvas, v, self.viscm_editor.name, parent=self)


### PR DESCRIPTION
- enum scoping change.
- exec vs. exec_.
- Matplotlib no longer exports _getSaveFileName (only PyQt4 required a separate _getSaveFileName because it called that function getSaveFileNameAndFilter instead; let's not try to support qt4 anymore).  Also, PyQt and PySide use different parameter names for this function; pass parameters positionally instead.
- addAction parameter order changed between qt5 and qt6, but we can call it in a way that's compatible with everyone by using setShortcut instead.
- QAction moved between qt5 and qt6 but we don't need to explicitly instantiate it; we can use addAction instead to do so.