### PR TITLE
Unit test refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test
 test:
 	python -m pytest --version
-	python -m pytest test/
+	python -m pytest -v test/
 
 
 .PHONY: lint 


### PR DESCRIPTION
Make the unit tests a bit easier to understand by splitting the attribute tests from the colormap value tests. Use `expected`/`actual` terminology to (IMO) improve test readability.

## ~Should be rebased after #66 is merged~

Still thinking about: how can these chained/dependent PRs be made easier to manage?