### PR TITLE
Enable auto-generated release notes to be categorized by PR label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - "releasenotes-ignore"
+  categories:
+    - title: "New features"
+      labels:
+        - "enhancement"
+    - title: "Bug fixes"
+      labels:
+        - "bug"
+    - title: "CI"
+      labels:
+        - "ci"
+    - title: "Documentation"
+      labels:
+        - "documentation"
+    - title: "Dependency updates"
+      labels:
+        - "dependencies"
+    - title: "Other changes"
+      labels:
+        - "*"


### PR DESCRIPTION
Currently, the release notes generated look like this, but I'd like to categorize the changes:

---

## What's Changed
* Fix crash when the file save dialog is cancelled by @robertguetzkow in https://github.com/matplotlib/viscm/pull/54
* Fix qt import, fixes #55 by @maxnoe in https://github.com/matplotlib/viscm/pull/57
* Modernize packaging config by @mfisher87 in https://github.com/matplotlib/viscm/pull/63
* Set up `ruff` & `black` with `pre-commit` and document usage by @mfisher87 in https://github.com/matplotlib/viscm/pull/64
* More precommit checks by @mfisher87 in https://github.com/matplotlib/viscm/pull/65
* Fixup original unit test, set up tests to run in GitHub Actions by @mfisher87 in https://github.com/matplotlib/viscm/pull/66
* Fix main branch actions failures, other pre-commit tweaks by @mfisher87 in https://github.com/matplotlib/viscm/pull/68
* Unit test refactor by @mfisher87 in https://github.com/matplotlib/viscm/pull/67
* Pep8 naming partial compliance by @mfisher87 in https://github.com/matplotlib/viscm/pull/70
* Add basic GUI tests by @mfisher87 in https://github.com/matplotlib/viscm/pull/72
* Add instructions on how to reproduce viridis by @stefanv in https://github.com/matplotlib/viscm/pull/58
* Add typechecking by @mfisher87 in https://github.com/matplotlib/viscm/pull/73
* Drop support for Python 3.8, Qt5, matplotlib 3.4, scipy 1.7, numpy 1.21 by @mfisher87 in https://github.com/matplotlib/viscm/pull/75
* Publish to PyPI automatically when publishing a GitHub release by @mfisher87 in https://github.com/matplotlib/viscm/pull/79

## New Contributors
* @robertguetzkow made their first contribution in https://github.com/matplotlib/viscm/pull/54
* @maxnoe made their first contribution in https://github.com/matplotlib/viscm/pull/57
* @mfisher87 made their first contribution in https://github.com/matplotlib/viscm/pull/63

**Full Changelog**: https://github.com/matplotlib/viscm/compare/v0.9...v0.10