### PR TITLE
TST: fix minimal requirement spec and add CPython 3.12 and 3.13 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,14 @@ jobs:
     strategy:
       matrix:
         python-version:
+          - "3.13"
+          - "3.12"
           - "3.11"
           - "3.10"
           - "3.9"
         pyqt-dependency:
-          - "PyQt6"
-          - "PySide6"
+          - "PyQt"
+          - "PySide"
 
     steps:
       - uses: "actions/checkout@v3"
@@ -30,16 +32,18 @@ jobs:
         run: |
           # Project dependencies from pyproject.toml
           # NOTE: Also builds viscm. How do we avoid this?
-          pip install .
+          pip install .[${{ matrix.pyqt-dependency }}]
 
           # Test dependencies
-          pip install pytest pytest-cov pytest-qt pytest-xvfb ${{ matrix.pyqt-dependency }}
+          pip install pytest pytest-cov pytest-qt pytest-xvfb
           # pytest-qt CI dependencies: https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions
           sudo apt update
           sudo apt install -y \
             xvfb libegl1 \
             libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils \
             libxcb-cursor0
+
+      - run: pip list
 
       - name: "Run tests"
         run: "make test"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ jobs:
   unit-test-and-typecheck:
     runs-on: "ubuntu-latest"
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,12 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 
-requires-python = "~=3.9"
+requires-python = ">=3.9"
 dependencies = [
-  "numpy ~=1.22",
-  "matplotlib ~=3.5",
-  "colorspacious ~=1.1",
-  "scipy ~=1.8",
+  "numpy >=1.22",
+  "matplotlib >=3.5",
+  "colorspacious >=1.1",
+  "scipy >=1.8",
 ]
 
 [project.optional-dependencies]

--- a/viscm/bezierbuilder/__init__.py
+++ b/viscm/bezierbuilder/__init__.py
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import numpy as np
-from matplotlib.backends.qt_compat import QtCore
+from matplotlib.backends.qt_compat import QtCore  # type: ignore [attr-defined]
 from matplotlib.lines import Line2D
 
 from viscm.bezierbuilder.curve import curve_method

--- a/viscm/gui.py
+++ b/viscm/gui.py
@@ -26,7 +26,11 @@ from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 # matplotlib.rcParams['backend'] = "QtAgg"
 # Do this first before any other matplotlib imports, to force matplotlib to
 # use a Qt backend
-from matplotlib.backends.qt_compat import QtCore, QtGui, QtWidgets
+from matplotlib.backends.qt_compat import (  # type: ignore [attr-defined]
+    QtCore,
+    QtGui,
+    QtWidgets,
+)
 from matplotlib.colors import ListedColormap
 from matplotlib.gridspec import GridSpec
 


### PR DESCRIPTION
My main motivation here was to replace `~=` with `>=` in dependency specs, because `numpy~=1.22` is resolved as `numpy>=1.22, <2`, which blocks downstream testing on Python 3.13 (which isn't supported by numpy<2).
While I was at it, I also added Python 3.12 and 3.13 to CI and "fixed" typechecking.
I gave this revised CI a spin on my fork and found that while everything is green with PyQt, some tests will fail against PySide6, which looks like an upstream bug to me (but I haven't digged much further).