### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"      # Location of your workflow files
+    schedule:
+      interval: "weekly"  # Options: daily, weekly, monthly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,8 @@
-
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"      # Location of your workflow files
     schedule:
       interval: "weekly"  # Options: daily, weekly, monthly
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"      # Location of your workflow files
+    directory: "/"
     schedule:
-      interval: "weekly"  # Options: daily, weekly, monthly
+      interval: "monthly"
     cooldown:
       default-days: 7

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v3"
+        with:
+          persist-credentials: false
 
       - name: "Set up Python ${{ matrix.python-version }}"
         uses: "actions/setup-python@v4"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,4 +1,6 @@
 name: "Check with pre-commit"
+permissions:
+  contents: read
 on:
   push:
     branches: ["main"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: "Release"
+permissions:
+  contents: read
 on:
   release:
     types:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,6 @@ jobs:
         run: "python -m build"
 
       - name: "Publish to PyPI"
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           password: "${{ secrets.PYPI_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@v3"
+        with:
+          persist-credentials: false
 
       - name: "Set up Python"
         uses: "actions/setup-python@v4"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: "Release"
 permissions:
-  contents: read
+  contents: "read"
 on:
   release:
     types:
@@ -27,6 +27,6 @@ jobs:
         run: "python -m build"
 
       - name: "Publish to PyPI"
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b" # v1.14.0
         with:
           password: "${{ secrets.PYPI_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,6 @@ jobs:
         run: "python -m build"
 
       - name: "Publish to PyPI"
-        uses: "pypa/gh-action-pypi-publish@release/v1"
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           password: "${{ secrets.PYPI_TOKEN }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v3"
+        with:
+          persist-credentials: false
 
       - name: "Set up Python ${{ matrix.python-version }}"
         uses: "actions/setup-python@v4"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: "Test"
+permissions:
+  contents: read
 on:
   push:
     branches: ["main"]

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,29 @@
+name: "GitHub Actions Security Analysis with zizmor 🌈"
+
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - ".github/workflows/*"
+  pull_request:
+    paths:
+      - ".github/workflows/*"
+
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: "Run zizmor 🌈"
+    runs-on: "ubuntu-latest"
+    permissions:
+      security-events: "write" # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: "Checkout repository"
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: "Run zizmor 🌈"
+        uses: "zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e" # v0.5.3


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions
- adding a depandabot file for GHA
