### PR TITLE
Add type-ignores for imports of matplotlib dynamic global objects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,12 +67,10 @@ python_version = "3.9"
 [[tool.mypy.overrides]]
 module = [
   "colorspacious",
-  "matplotlib.*",
   "mpl_toolkits.*",
   "scipy.*",
 ]
 ignore_missing_imports = true
-
 
 
 [tool.black]

--- a/viscm/bezierbuilder/__init__.py
+++ b/viscm/bezierbuilder/__init__.py
@@ -26,7 +26,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """
 
 import numpy as np
-from matplotlib.backends.qt_compat import QtCore
+from matplotlib.backends.qt_compat import QtCore  # type: ignore[attr-defined]
 from matplotlib.lines import Line2D
 
 from viscm.bezierbuilder.curve import curve_method

--- a/viscm/gui.py
+++ b/viscm/gui.py
@@ -26,7 +26,11 @@ from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 # matplotlib.rcParams['backend'] = "QtAgg"
 # Do this first before any other matplotlib imports, to force matplotlib to
 # use a Qt backend
-from matplotlib.backends.qt_compat import QtCore, QtGui, QtWidgets
+from matplotlib.backends.qt_compat import (  # type: ignore[attr-defined]
+    QtCore,
+    QtGui,
+    QtWidgets,
+)
 from matplotlib.colors import ListedColormap
 from matplotlib.gridspec import GridSpec
 


### PR DESCRIPTION
Matplotlib dynamically exposes global objects from its different Qt dependencies depending on which are installed. The type checker isn't capable of handling this. This wasn't a problem before because matplotlib didn't ship type stubs so we used `ignore_missing_imports` to ignore errors. Now that matplotlib ships stubs, mypy can find these modules and typecheck them, and we get different errors. We can remove the `ignore_missing_imports` setting for matplotlib and use targeted type-ignores instead.