### PR TITLE
Drop support for Pythons 3.9 - 3.11

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: "ubuntu-latest"
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.14"]
 
     steps:
       - uses: "actions/checkout@v3"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: "Set up Python"
         uses: "actions/setup-python@v4"
         with:
-          python-version: "3.9"
+          python-version: "3.12"
 
       - name: "Install build tool"
         run: "pip install --user build"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.11"
-          - "3.10"
-          - "3.9"
+          - "3.14"
+          - "3.13"
+          - "3.12"
         pyqt-dependency:
           - "PyQt6"
           - "PySide6"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
   - repo: "https://github.com/charliermarsh/ruff-pre-commit"
     rev: "v0.15.14"
     hooks:
-      - id: "ruff"
+      - id: "ruff-check"
         # NOTE: "--exit-non-zero-on-fix" is important for CI to function
         # correctly!
         args: ["--fix", "--exit-non-zero-on-fix"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,6 @@ repos:
         args: ["--fix", "--exit-non-zero-on-fix"]
 
   - repo: "https://github.com/psf/black"
-    rev: "23.3.0"
+    rev: "26.5.1"
     hooks:
       - id: "black"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: "end-of-file-fixer"
 
   - repo: "https://github.com/charliermarsh/ruff-pre-commit"
-    rev: "v0.0.269"
+    rev: "v0.15.14"
     hooks:
       - id: "ruff"
         # NOTE: "--exit-non-zero-on-fix" is important for CI to function

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Contact:
   Nathaniel J. Smith <njs@pobox.com> and Stéfan van der Walt <stefanv@berkeley.edu>
 
 Dependencies:
-  * Python 3.9+
+  * Python 3.12+
   * `colorspacious <https://pypi.python.org/pypi/colorspacious>`_ 1.1+
   * Matplotlib 3.5+
   * NumPy 1.22+

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
   - "nodefaults"
 dependencies:
   # Runtime
-  - "python ~=3.11"
+  - "python ~=3.12"
   - "numpy ~=1.24"
   - "matplotlib ~=3.7"
   - "colorspacious ~=1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,13 @@ select = [
   "T10",
   "RUF",
 ]
+ignore = [
+  "B905",
+  "UP031",
+  "RUF005",
+  "RUF046",
+  "RUF059",
+]
 
 [tool.ruff.lint.per-file-ignores]
 "viscm/gui.py" = ["N8"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 
-requires-python = "~=3.9"
+requires-python = ">=3.12"
 dependencies = [
   "numpy ~=1.22",
   "matplotlib ~=3.5",
@@ -60,7 +60,7 @@ package-data = {viscm = ["examples/*"]}
 
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.12"
 
 # These libraries don't have type stubs. Mypy will see them as `Any` and not
 # throw an [import] error.
@@ -74,10 +74,10 @@ ignore_missing_imports = true
 
 
 [tool.black]
-target-version = ["py39", "py310", "py311"]
+target-version = ["py312", "py313", "py314"]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py312"
 select = [
   "F",
   "E",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,12 +73,6 @@ module = [
 ignore_missing_imports = true
 
 
-[tool.black]
-target-version = ["py312", "py313", "py314"]
-
-[tool.ruff]
-target-version = "py312"
-
 [tool.ruff.lint]
 select = [
   "F",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,8 @@ target-version = ["py312", "py313", "py314"]
 
 [tool.ruff]
 target-version = "py312"
+
+[tool.ruff.lint]
 select = [
   "F",
   "E",
@@ -94,8 +96,8 @@ select = [
   "RUF",
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "viscm/gui.py" = ["N8"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,10 @@ classifiers = [
 
 requires-python = ">=3.12"
 dependencies = [
-  "numpy ~=1.22",
-  "matplotlib ~=3.5",
-  "colorspacious ~=1.1",
-  "scipy ~=1.8",
+  "numpy >=1.22",
+  "matplotlib >=3.5",
+  "colorspacious >=1.1",
+  "scipy >=1.8",
 ]
 
 [project.optional-dependencies]

--- a/test/data/option_d.py
+++ b/test/data/option_d.py
@@ -11,6 +11,7 @@ to mpl-colormaps.
 You should have received a copy of the CC0 legalcode along with this
 work.  If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
 """
+
 from matplotlib.colors import LinearSegmentedColormap
 
 # Used to reconstruct the colormap in viscm

--- a/viscm/cli.py
+++ b/viscm/cli.py
@@ -1,6 +1,5 @@
 import sys
 from pathlib import Path
-from typing import Union
 
 import matplotlib.pyplot as plt
 
@@ -117,13 +116,13 @@ def cli():
 def _make_window(
     *,
     action: str,
-    cmap: Union[str, None],
+    cmap: str | None,
     cmap_type: str,
     cmap_spline_method: str,
     cmap_uniform_space: str,
-    save: Union[Path, None],
+    save: Path | None,
     quit_immediately: bool,
-) -> Union[gui.ViewerWindow, gui.EditorWindow]:
+) -> gui.ViewerWindow | gui.EditorWindow:
     # Hold a reference so it doesn't get GC'ed
     fig = plt.figure()
     figure_canvas = gui.FigureCanvas(fig)
@@ -132,7 +131,7 @@ def _make_window(
     if cmap:
         cm.load(cmap)
 
-    v: Union[gui.viscm, gui.viscm_editor]
+    v: gui.viscm | gui.viscm_editor
     # Easter egg! I keep typing 'show' instead of 'view' so accept both
     if action in ("view", "show"):
         if cm is None:

--- a/viscm/gui.py
+++ b/viscm/gui.py
@@ -284,7 +284,9 @@ class viscm:
         title(ax, "Perceptual derivative")
         label(
             ax,
-            f"Length: {arclength:0.1f}\nRMS deviation from flat: {rmse:0.1f} ({100 * rmse / arclength:0.1f}%)",
+            f"Length: {arclength:0.1f}"
+            f"\nRMS deviation from flat: {rmse:0.1f}"
+            f" ({100 * rmse / arclength:0.1f}%)",
         )
         ax.set_ylim(-delta_ymax(-local_derivs), delta_ymax(local_derivs))
         ax.get_xaxis().set_visible(False)
@@ -306,7 +308,9 @@ class viscm:
         lightness_rmse = np.std(lightness_derivs)
         label(
             ax,
-            f"Length: {lightness_arclength:0.1f}\nRMS deviation from flat: {lightness_rmse:0.1f} ({100 * lightness_rmse / lightness_arclength:0.1f}%)",
+            f"Length: {lightness_arclength:0.1f}"
+            f"\nRMS deviation from flat: {lightness_rmse:0.1f}"
+            f" ({100 * lightness_rmse / lightness_arclength:0.1f}%)",
         )
 
         ax.set_ylim(-delta_ymax(-lightness_derivs), delta_ymax(lightness_derivs))

--- a/viscm/gui.py
+++ b/viscm/gui.py
@@ -284,9 +284,7 @@ class viscm:
         title(ax, "Perceptual derivative")
         label(
             ax,
-            "Length: {:0.1f}\nRMS deviation from flat: {:0.1f} ({:0.1f}%)".format(
-                arclength, rmse, 100 * rmse / arclength
-            ),
+            f"Length: {arclength:0.1f}\nRMS deviation from flat: {rmse:0.1f} ({100 * rmse / arclength:0.1f}%)",
         )
         ax.set_ylim(-delta_ymax(-local_derivs), delta_ymax(local_derivs))
         ax.get_xaxis().set_visible(False)
@@ -308,11 +306,7 @@ class viscm:
         lightness_rmse = np.std(lightness_derivs)
         label(
             ax,
-            "Length: {:0.1f}\nRMS deviation from flat: {:0.1f} ({:0.1f}%)".format(
-                lightness_arclength,
-                lightness_rmse,
-                100 * lightness_rmse / lightness_arclength,
-            ),
+            f"Length: {lightness_arclength:0.1f}\nRMS deviation from flat: {lightness_rmse:0.1f} ({100 * lightness_rmse / lightness_arclength:0.1f}%)",
         )
 
         ax.set_ylim(-delta_ymax(-lightness_derivs), delta_ymax(lightness_derivs))
@@ -707,16 +701,14 @@ class viscm_editor:
     def export_py(self, filepath):
         import textwrap
 
-        template = textwrap.dedent(
-            """
+        template = textwrap.dedent("""
         from matplotlib.colors import ListedColormap
 
         cm_type = "{type}"
 
         cm_data = {array_list}
         test_cm = ListedColormap(cm_data, name="{name}")
-        """
-        )
+        """)
         rgb, _ = self.cmap_model.get_sRGB(num=256)
         array_list = np.array2string(
             rgb, max_line_width=78, prefix="cm_data = ", separator=","


### PR DESCRIPTION
Per [SPEC0](https://scientific-python.org/specs/spec-0000/)

Supercedes #84 -- thanks @neutrinoceros for your 2-year-old PR I never reviewed. Credited you as co-author!

* Drop old versions of Python
* Update CI to test with new versions
* Update tooling (ruff, Black) for compatibility with new versions of Python
    * Run autofixes with new tool versions
    * Update tooling config to ignore some rules and avoid sidetrack and PR bloat
* ?
