### PR TITLE
Use trusted publishing when publishing to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,26 @@ jobs:
       - name: "Build binary dist (wheel) and source dist"
         run: "python -m build"
 
-      - name: "Publish to PyPI"
-        uses: "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b" # v1.14.0
+      - uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7.0.1
         with:
-          password: "${{ secrets.PYPI_TOKEN }}"
+          name: "dist"
+          path: "dist/"
+
+  pypi-publish:
+    name: "Upload dist to PyPI"
+    needs: "build"
+    runs-on: "ubuntu-latest"
+    environment:
+      name: "pypi"
+      url: "https://pypi.org/p/viscm"
+    permissions:
+      id-token: "write"
+    steps:
+      - name: "Get build artifact"
+        uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8.0.1
+        with:
+          name: "dist"
+          path: "dist/"
+
+      - name: "Upload dist to PyPI"
+        uses: "pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b" # release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
 
-  build-and-release:
+  build:
     runs-on: "ubuntu-latest"
     steps:
       - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2


### PR DESCRIPTION
Resolves #92 