### PR TITLE
Increase dependency lower bounds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 
 requires-python = ">=3.12"
 dependencies = [
-  "numpy >=1.22",
+  "numpy >=1.26",
   "matplotlib >=3.5",
   "colorspacious >=1.1",
   "scipy >=1.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "numpy >=1.26",
   "matplotlib >=3.5",
   "colorspacious >=1.1",
-  "scipy >=1.8",
+  "scipy >=1.12",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Omit versions of dependencies that can't be installed now that we've upgraded our minimum supported version of Python to 3.12.