### PR TITLE
Pass missing attributes to base cmap

### DIFF
--- a/viscm/gui.py
+++ b/viscm/gui.py
@@ -113,11 +113,7 @@ def _setup_Jpapbp_axis(ax):
 # Adapt a matplotlib colormap to a linearly transformed version -- useful for
 # visualizing how colormaps look given color deficiency.
 # Kinda a hack, b/c we inherit from Colormap (this is required), but then
-# ignore its implementation entirely. This results in errors at runtime:
-#       File "/<env>/site-packages/matplotlib/artist.py", line 1343, in format_cursor_data  # noqa: E501
-#         n = self.cmap.N
-#             ^^^^^^^^^^^
-#     AttributeError: 'TransformedCMap' object has no attribute 'N'
+# ignore its implementation entirely.
 class TransformedCMap(matplotlib.colors.Colormap):
     def __init__(self, transform, base_cmap):
         self.transform = transform
@@ -131,17 +127,8 @@ class TransformedCMap(matplotlib.colors.Colormap):
             return (tfx * 255).astype("uint8")
         return tfx
 
-    def set_bad(self, *args, **kwargs):
-        self.base_cmap.set_bad(*args, **kwargs)
-
-    def set_under(self, *args, **kwargs):
-        self.base_cmap.set_under(*args, **kwargs)
-
-    def set_over(self, *args, **kwargs):
-        self.base_cmap.set_over(*args, **kwargs)
-
-    def is_gray(self):
-        return False
+    def __getattr__(self, name):
+        return getattr(self.base_cmap, name)
 
 
 def _vis_axes(fig):


### PR DESCRIPTION
Hi,

The TransformedCMap wrapper fails to get attributes of the basemap. Currently it is failing with `TransformedCMap object has not attribute 'n_variates'`. Rather than duplicating the API of Colormap, by using [`__getattr__`](https://docs.python.org/3/reference/datamodel.html#object.__getattr__) we can pass missing attribute calls to the base colormap object.

It is still a bit hackish, but it should avoid problems in the future.